### PR TITLE
fix(Home): remove priority flag from profile pic

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -48,7 +48,6 @@ export default async function Home() {
             src={profilePic}
             className="rounded-full"
             style={{ objectFit: "contain" }}
-            priority={true}
             alt="Andrew Pethoud smiling while posing for a profile photo" />
         </div>
       </div>


### PR DESCRIPTION
The First Contentful Paint was faster without the priority flag on the profile pic, for some reason. Reverting to see if that fixes the problem, now that the image itself has been optimized.